### PR TITLE
Rename irregularly changed classes

### DIFF
--- a/test-projects/random-files/pom.xml
+++ b/test-projects/random-files/pom.xml
@@ -14,8 +14,8 @@
 	</prerequisites>
 
 	<properties>
-		<vaadin.version>8.0.0.beta1</vaadin.version>
-		<vaadin.plugin.version>8.0.0.beta1</vaadin.plugin.version>
+		<vaadin.version>8.0.5</vaadin.version>
+		<vaadin.plugin.version>8.0.5</vaadin.plugin.version>
 		<jetty.plugin.version>9.3.9.v20160517</jetty.plugin.version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<maven.compiler.source>1.8</maven.compiler.source>

--- a/test-projects/random-files/src/main/java/com/vaadin/random/files/LabelModes.java
+++ b/test-projects/random-files/src/main/java/com/vaadin/random/files/LabelModes.java
@@ -1,0 +1,39 @@
+package com.vaadin.random.files;
+
+import com.vaadin.data.fieldgroup.PropertyId;
+import com.vaadin.shared.ui.label.ContentMode;
+import com.vaadin.ui.Label;
+
+public class LabelModes extends com.vaadin.ui.VerticalLayout {
+    
+    @PropertyId("mine")
+    public Label myLabel;
+
+    protected void initializeComponents() {
+
+        Label l;
+        l = new Label(
+                "This is an undefined wide label with default content mode");
+        l.setWidth(null);
+        addComponent(l);
+
+        l = new Label(
+                "This label                       contains\nnewlines and spaces\nbut is in\ndefault content mode");
+        l.setWidth(null);
+        addComponent(l);
+
+        l = new Label(
+                "This label                       contains\nnewlines and spaces\nand is in\npreformatted mode");
+        l.setContentMode(ContentMode.PREFORMATTED);
+        l.setWidth(null);
+        addComponent(l);
+
+        l = new Label(
+                "This label                       contains\nnewlines and spaces\nand is in\nhtml mode");
+        l.setContentMode(ContentMode.HTML);
+        l.setWidth(null);
+        addComponent(l);
+
+    }
+
+}


### PR DESCRIPTION
This change updates package paths for the classes Range and PropertyId,
which do not follow the standard pattern of prepending v7.

Fixes #27, fixes #30

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/framework8-migration-tool/31)
<!-- Reviewable:end -->
